### PR TITLE
Fixed ignored QueryAttribute.Name when set using property setter

### DIFF
--- a/src/RestEase/QueryAttribute.cs
+++ b/src/RestEase/QueryAttribute.cs
@@ -16,7 +16,7 @@ namespace RestEase
         /// <summary>
         /// Gets a value indicating whether the user has set the name attribute
         /// </summary>
-        public bool HasName { get; }
+        public bool HasName => Name != null;
 
         /// <summary>
         /// Gets the serialization method to use to serialize the value. Defaults to QuerySerializationMethod.ToString
@@ -34,7 +34,7 @@ namespace RestEase
         /// Initialises a new instance of the <see cref="QueryAttribute"/> class
         /// </summary>
         public QueryAttribute()
-            : this(null, false, QuerySerializationMethod.Default)
+            : this(null, QuerySerializationMethod.Default)
         {
         }
 
@@ -43,7 +43,7 @@ namespace RestEase
         /// </summary>
         /// <param name="name">Name of the query parameter</param>
         public QueryAttribute(string name)
-            : this(name, true, QuerySerializationMethod.Default)
+            : this(name, QuerySerializationMethod.Default)
         {
         }
 
@@ -52,7 +52,7 @@ namespace RestEase
         /// </summary>
         /// <param name="serializationMethod">Serialization method to use to serialize the value</param>
         public QueryAttribute(QuerySerializationMethod serializationMethod)
-            : this(null, false, serializationMethod)
+            : this(null, serializationMethod)
         {
         }
 
@@ -62,14 +62,8 @@ namespace RestEase
         /// <param name="name">Name of the query parameter</param>
         /// <param name="serializationMethod">Serialization method to use to serialize the value</param>
         public QueryAttribute(string name, QuerySerializationMethod serializationMethod)
-            : this(name, true, serializationMethod)
-        {
-        }
-
-        private QueryAttribute(string name, bool hasName, QuerySerializationMethod serializationMethod)
         {
             this.Name = name;
-            this.HasName = hasName;
             this.SerializationMethod = serializationMethod;
         }
     }

--- a/src/RestEase/QueryAttribute.cs
+++ b/src/RestEase/QueryAttribute.cs
@@ -8,15 +8,25 @@ namespace RestEase
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
     public sealed class QueryAttribute : Attribute
     {
+        private string _name;
+
         /// <summary>
-        /// Gets or sets the name of the query param. Will use the parameter / property name if null
+        /// Gets or sets the name of the query param. Will NOT use the parameter / property name if null.
         /// </summary>
-        public string Name { get; set; }
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                HasName = true;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether the user has set the name attribute
         /// </summary>
-        public bool HasName => Name != null;
+        public bool HasName { get; private set; }
 
         /// <summary>
         /// Gets the serialization method to use to serialize the value. Defaults to QuerySerializationMethod.ToString
@@ -34,7 +44,7 @@ namespace RestEase
         /// Initialises a new instance of the <see cref="QueryAttribute"/> class
         /// </summary>
         public QueryAttribute()
-            : this(null, QuerySerializationMethod.Default)
+            : this(null, false, QuerySerializationMethod.Default)
         {
         }
 
@@ -43,7 +53,7 @@ namespace RestEase
         /// </summary>
         /// <param name="name">Name of the query parameter</param>
         public QueryAttribute(string name)
-            : this(name, QuerySerializationMethod.Default)
+            : this(name, true, QuerySerializationMethod.Default)
         {
         }
 
@@ -52,7 +62,7 @@ namespace RestEase
         /// </summary>
         /// <param name="serializationMethod">Serialization method to use to serialize the value</param>
         public QueryAttribute(QuerySerializationMethod serializationMethod)
-            : this(null, serializationMethod)
+            : this(null, false, serializationMethod)
         {
         }
 
@@ -62,8 +72,14 @@ namespace RestEase
         /// <param name="name">Name of the query parameter</param>
         /// <param name="serializationMethod">Serialization method to use to serialize the value</param>
         public QueryAttribute(string name, QuerySerializationMethod serializationMethod)
+            : this(name, true, serializationMethod)
+        {
+        }
+
+        private QueryAttribute(string name, bool hasName, QuerySerializationMethod serializationMethod)
         {
             this.Name = name;
+            this.HasName = hasName;
             this.SerializationMethod = serializationMethod;
         }
     }

--- a/src/RestEase/QueryAttribute.cs
+++ b/src/RestEase/QueryAttribute.cs
@@ -11,7 +11,7 @@ namespace RestEase
         private string _name;
 
         /// <summary>
-        /// Gets or sets the name of the query param. Will NOT use the parameter / property name if null.
+        /// Gets or sets the name of the query param. Will use the parameter / property name if unset.
         /// </summary>
         public string Name
         {
@@ -19,7 +19,7 @@ namespace RestEase
             set
             {
                 _name = value;
-                HasName = true;
+                this.HasName = true;
             }
         }
 

--- a/src/RestEaseUnitTests/ImplementationBuilderTests/QueryParamTests.cs
+++ b/src/RestEaseUnitTests/ImplementationBuilderTests/QueryParamTests.cs
@@ -260,7 +260,7 @@ namespace RestEaseUnitTests.ImplementationBuilderTests
             var queryParams = requestInfo.QueryParams.ToList();
 
             Assert.Single(queryParams);
-            Assert.Equal("rawQuery", queryParams[0].SerializeToString(null).First().Key);
+            Assert.Null(queryParams[0].SerializeToString(null).First().Key);
         }
 
         [Fact]

--- a/src/RestEaseUnitTests/ImplementationBuilderTests/QueryParamTests.cs
+++ b/src/RestEaseUnitTests/ImplementationBuilderTests/QueryParamTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -112,6 +111,18 @@ namespace RestEaseUnitTests.ImplementationBuilderTests
 
             [Get("foo")]
             Task FooAsync();
+        }
+
+        public interface IHasQueryParameterNameUsingAttributeSetter
+        {
+            [Get]
+            Task FooAsync([Query(Name = "customName")] string queryParameter);
+        }
+
+        public interface IHasQueryParameterNameUsingAttributeConstructor
+        {
+            [Get]
+            Task FooAsync([Query("customName")] string queryParameter);
         }
 
         public interface IHasSerializedPathQuery
@@ -249,7 +260,7 @@ namespace RestEaseUnitTests.ImplementationBuilderTests
             var queryParams = requestInfo.QueryParams.ToList();
 
             Assert.Single(queryParams);
-            Assert.Null(queryParams[0].SerializeToString(null).First().Key);
+            Assert.Equal("rawQuery", queryParams[0].SerializeToString(null).First().Key);
         }
 
         [Fact]
@@ -336,6 +347,34 @@ namespace RestEaseUnitTests.ImplementationBuilderTests
             Assert.Single(serialized);
             Assert.Equal("Woo", serialized[0].Key);
             Assert.Equal("A", serialized[0].Value);
+        }
+
+        [Fact]
+        public void HandlesQueryParameterNameUsingAttributeSetter()
+        {
+            var requestInfo = Request<IHasQueryParameterNameUsingAttributeSetter>(x => x.FooAsync("foo"));
+
+            var queryParameters = requestInfo.QueryParams.ToList();
+
+            Assert.Single(queryParameters);
+
+            var serialized = queryParameters[0].SerializeToString(null).ToList();
+            Assert.Single(serialized);
+            Assert.Equal("customName", serialized[0].Key);
+        }
+
+        [Fact]
+        public void HandlesQueryParameterNameUsingAttributeConstructor()
+        {
+            var requestInfo = Request<IHasQueryParameterNameUsingAttributeConstructor>(x => x.FooAsync("foo"));
+
+            var queryParameters = requestInfo.QueryParams.ToList();
+
+            Assert.Single(queryParameters);
+
+            var serialized = queryParameters[0].SerializeToString(null).ToList();
+            Assert.Single(serialized);
+            Assert.Equal("customName", serialized[0].Key);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed ignored QueryAttribute.Name when set using property setter ([Query(Name = "customName"))

I also harmonized the behavior the QueryAttribute.Name description:

"Will use the parameter / property name if null"

Previous implentation didn't use parameter/property name if set to null using QueryAttribute constructor.