### PR TITLE
adds ability to send 'null' in request body.

### DIFF
--- a/src/RestEase/Implementation/BodyParameterInfo.cs
+++ b/src/RestEase/Implementation/BodyParameterInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RestEase.Implementation;
+using System;
 using System.Net.Http;
 
 namespace RestEase.Implementation
@@ -17,6 +18,11 @@ namespace RestEase.Implementation
         /// Gets the body to serialize, as an object
         /// </summary>
         public object ObjectValue { get; protected set; }
+
+        /// <summary>
+        /// Gets type of body
+        /// </summary>
+        public abstract Type ObjectType { get; }
 
         /// <summary>
         /// Serialize the (typed) value using the given serializer
@@ -39,6 +45,11 @@ namespace RestEase.Implementation
         public T Value { get; private set; }
 
         /// <summary>
+        /// Gets type of body
+        /// </summary>
+        public override Type ObjectType { get; }
+
+        /// <summary>
         /// Initialises a new instance of the <see cref="BodyParameterInfo{T}"/> class
         /// </summary>
         /// <param name="serializationMethod">Method to use the serialize the body</param>
@@ -48,6 +59,7 @@ namespace RestEase.Implementation
             this.SerializationMethod = serializationMethod;
             this.ObjectValue = value;
             this.Value = value;
+            this.ObjectType = typeof(T);
         }
 
         /// <summary>

--- a/src/RestEase/Implementation/Requester.cs
+++ b/src/RestEase/Implementation/Requester.cs
@@ -151,7 +151,7 @@ namespace RestEase.Implementation
             IEnumerable<QueryParameterInfo> queryParams,
             IEnumerable<QueryParameterInfo> queryProperties,
             IRequestInfo requestInfo)
-        { 
+        {
             var serializedQueryParams = queryParams.SelectMany(x => this.SerializeQueryParameter(x, requestInfo));
             var serializedQueryProperties = queryProperties.SelectMany(x => this.SerializeQueryParameter(x, requestInfo));
 
@@ -272,20 +272,30 @@ namespace RestEase.Implementation
         /// <returns>null if no body is set, otherwise a suitable HttpContent (StringContent, StreamContent, FormUrlEncodedContent, etc)</returns>
         protected virtual HttpContent ConstructContent(IRequestInfo requestInfo)
         {
-            if (requestInfo.BodyParameterInfo == null || requestInfo.BodyParameterInfo.ObjectValue == null)
+            if (requestInfo.BodyParameterInfo == null)
+            {
                 return null;
+            }
 
-            if (requestInfo.BodyParameterInfo.ObjectValue is HttpContent httpContentValue)
-                return httpContentValue;
+            if (typeof(HttpContent).GetTypeInfo().IsAssignableFrom(requestInfo.BodyParameterInfo.ObjectType.GetTypeInfo()))
+            {
+                return requestInfo.BodyParameterInfo.ObjectValue == null ? null : requestInfo.BodyParameterInfo.ObjectValue as HttpContent;
+            }
 
-            if (requestInfo.BodyParameterInfo.ObjectValue is Stream streamValue)
-                return new StreamContent(streamValue);
+            if (typeof(Stream).GetTypeInfo().IsAssignableFrom(requestInfo.BodyParameterInfo.ObjectType.GetTypeInfo()))
+            {
+                return requestInfo.BodyParameterInfo.ObjectValue == null ? null : new StreamContent(requestInfo.BodyParameterInfo.ObjectValue as Stream);
+            }
 
-            if (requestInfo.BodyParameterInfo.ObjectValue is string stringValue)
-                return new StringContent(stringValue);
+            if (typeof(string).GetTypeInfo().IsAssignableFrom(requestInfo.BodyParameterInfo.ObjectType.GetTypeInfo()))
+            {
+                return requestInfo.BodyParameterInfo.ObjectValue == null ? null : new StringContent(requestInfo.BodyParameterInfo.ObjectValue as string);
+            }
 
-            if (requestInfo.BodyParameterInfo.ObjectValue is byte[] byteArrayValue)
-                return new ByteArrayContent(byteArrayValue);
+            if (typeof(byte[]).GetTypeInfo().IsAssignableFrom(requestInfo.BodyParameterInfo.ObjectType.GetTypeInfo()))
+            {
+                return requestInfo.BodyParameterInfo.ObjectValue == null ? null : new ByteArrayContent(requestInfo.BodyParameterInfo.ObjectValue as byte[]);
+            }
 
             switch (requestInfo.BodyParameterInfo.SerializationMethod)
             {

--- a/src/RestEase/JsonRequestBodySerializer.cs
+++ b/src/RestEase/JsonRequestBodySerializer.cs
@@ -16,9 +16,6 @@ namespace RestEase
         /// <inheritdoc/>
         public override HttpContent SerializeBody<T>(T body, RequestBodySerializerInfo info)
         {
-            if (body == null)
-                return null;
-
             var content = new StringContent(JsonConvert.SerializeObject(body, this.JsonSerializerSettings));
             content.Headers.ContentType.MediaType = "application/json";
             return content;

--- a/src/RestEaseUnitTests/RequesterTests/ContentConstructionTests.cs
+++ b/src/RestEaseUnitTests/RequesterTests/ContentConstructionTests.cs
@@ -28,22 +28,23 @@ namespace RestEaseUnitTests.RequesterTests
         }
 
         [Fact]
-        public void SetsContentNullIfBodyValueIsNull()
-        {
-            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
-            requestInfo.SetBodyParameterInfo<object>(BodySerializationMethod.Serialized, null);
-            var content = this.requester.ConstructContent(requestInfo);
-            Assert.Null(content);
-        }
-
-        [Fact]
         public void SetsContentAsHttpContentIfBodyIsHttpContent()
         {
             var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
-            var content = new StringContent("test");
+            var content = new StringContent("test") as HttpContent;
             requestInfo.SetBodyParameterInfo(BodySerializationMethod.Serialized, content);
 
             Assert.Equal(content, this.requester.ConstructContent(requestInfo));
+        }
+
+        [Fact]
+        public void SetsContentNullIfBodyHttpContentAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<HttpContent>(BodySerializationMethod.Serialized, null);
+            var content = this.requester.ConstructContent(requestInfo);
+
+            Assert.Null(content);
         }
 
         [Fact]
@@ -57,6 +58,16 @@ namespace RestEaseUnitTests.RequesterTests
         }
 
         [Fact]
+        public void SetsContentNullIfBodyIsStreamAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<MemoryStream>(BodySerializationMethod.Serialized, null);
+            var content = this.requester.ConstructContent(requestInfo);
+
+            Assert.Null(content);
+        }
+
+        [Fact]
         public void SetsContentAsStringContentIfBodyIsString()
         {
             var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
@@ -67,6 +78,16 @@ namespace RestEaseUnitTests.RequesterTests
         }
 
         [Fact]
+        public void SetsContentNullIfBodyIsStringAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<string>(BodySerializationMethod.Serialized, null);
+            var content = this.requester.ConstructContent(requestInfo);
+
+            Assert.Null(content);
+        }
+
+        [Fact]
         public void SetContentAsByteArrayContentIfBodyIsByteArray()
         {
             var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
@@ -74,6 +95,36 @@ namespace RestEaseUnitTests.RequesterTests
             var content = this.requester.ConstructContent(requestInfo);
 
             Assert.IsType<ByteArrayContent>(content);
+        }
+
+        [Fact]
+        public void SetsContentNullIfBodyIsByteArrayAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<byte[]>(BodySerializationMethod.Serialized, null);
+            var content = this.requester.ConstructContent(requestInfo);
+
+            Assert.Null(content);
+        }
+
+        [Fact]
+        public void SetsContentAsStringContentIfContentBodyIsObjectAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<object>(BodySerializationMethod.Serialized, null);
+            var content = this.requester.ConstructContent(requestInfo);
+
+            Assert.IsType<StringContent>(content);
+        }
+
+        [Fact]
+        public async Task SetsStringContentValueAsNullStringValueIfContentBodyIsObjectAndValueIsNull()
+        {
+            var requestInfo = new RequestInfo(HttpMethod.Get, "foo");
+            requestInfo.SetBodyParameterInfo<object>(BodySerializationMethod.Serialized, null);
+            var contentValue = await this.requester.ConstructContent(requestInfo).ReadAsStringAsync();
+
+            Assert.Equal("null", contentValue, ignoreCase: true);
         }
 
         [Fact]


### PR DESCRIPTION
basically the idea is to check type of body in runtime and provides serializer ability to work with null objects.
backward compatibility saved.