### PR TITLE
Suffix name for type with additional assembly name

### DIFF
--- a/src/RestEase/Implementation/ImplementationBuilder.cs
+++ b/src/RestEase/Implementation/ImplementationBuilder.cs
@@ -216,10 +216,14 @@ namespace RestEase.Implementation
                     this.AddFriendlierNameForType(sb, arg);
                 }
                 sb.Append("]");
+                sb.Append(" ");
+                sb.Append(typeInfo.Assembly.GetName().Name);
             }
             else
             {
                 sb.Append(type.FullName.Replace('.', '+'));
+                sb.Append(" ");
+                sb.Append(typeInfo.Assembly.GetName().Name);
             }
         }
 


### PR DESCRIPTION
Suffix name for type with additional assembly name so there is no conflict when the same typename is used in different assemblies (This happens frequently in linqpad interactive sessions because each change in a script creates a new assembly which is loaded into the currently running app domain).

This is the exception which occurs in linqpad after the second change to a script:

![image](https://user-images.githubusercontent.com/338856/55710251-8334b680-59ea-11e9-88ea-aaab692874d4.png)
