### PR TITLE
close #171 allow multiple parameter attributes

### DIFF
--- a/src/Common/Implementation/DiagnosticCode.cs
+++ b/src/Common/Implementation/DiagnosticCode.cs
@@ -46,6 +46,7 @@
         RestEaseVersionTooOld = 37,
         RestEaseVersionTooNew = 38,
         MethodMustHaveOneRequestAttribute = 39,
+        QueryConflictWithRawQueryString = 40,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 

--- a/src/Common/Implementation/DiagnosticCode.cs
+++ b/src/Common/Implementation/DiagnosticCode.cs
@@ -1,4 +1,6 @@
-﻿namespace RestEase.Implementation
+﻿using System;
+
+namespace RestEase.Implementation
 {
     /// <summary>
     /// Identifies the type of error / diagnostic encountered during emission
@@ -31,6 +33,7 @@
         MultipleHttpRequestMessagePropertiesForKey = 22,
         HttpRequestMessageParamDuplicatesPropertyForKey = 23,
         MultipleHttpRequestMessageParametersForKey = 24,
+        [Obsolete("No longer used")]
         ParameterMustHaveZeroOrOneAttributes = 25,
         CancellationTokenMustHaveZeroAttributes = 26,
         CouldNotFindRestEaseType = 27,

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
@@ -204,13 +204,6 @@ namespace RestEase.Implementation.Emission
                 $"Method '{method.MethodInfo.Name}': found more than one parameter with a HttpRequestMessageProperty key of '{key}'");
         }
 
-        public void ReportParameterMustHaveZeroOrOneAttributes(MethodModel method, ParameterModel parameter, List<AttributeModel> attributes)
-        {
-            throw new ImplementationCreationException(
-                DiagnosticCode.ParameterMustHaveZeroOrOneAttributes,
-                $"Method '{method.MethodInfo.Name}': parameter '{parameter.Name}' has {attributes.Count} attributes, but it must have zero or one");
-        }
-
         public void ReportParameterMustNotBeByRef(MethodModel method, ParameterModel parameter)
         {
             throw new ImplementationCreationException(

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
@@ -260,6 +260,13 @@ namespace RestEase.Implementation.Emission
                 DiagnosticCode.MethodMustHaveValidReturnType,
                 $"Method '{method.MethodInfo.Name}': must have a return type of Task<T> or Task");
         }
+
+        public void ReportQueryAttributeConflictWithRawQueryString(MethodModel method, ParameterModel parameter)
+        {
+            throw new ImplementationCreationException(
+                DiagnosticCode.QueryConflictWithRawQueryString,
+                $"Method '{method.MethodInfo.Name}': parameter '{parameter.Name}', [RawQueryString] must not be specified along with [Query]");
+        }
     }
 }
 

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
@@ -180,7 +180,7 @@ namespace RestEase.Implementation.Emission
         {
             throw new ImplementationCreationException(
                 DiagnosticCode.MissingPlaceholderForPathParameter,
-                $"Method '{method.MethodInfo.Name}': unable to find to find a placeholder {{{placeholder}}} for the path parameter '{placeholder}'");
+                $"Method '{method.MethodInfo.Name}': unable to find a placeholder {{{placeholder}}} for the path parameter '{placeholder}'");
         }
 
         public void ReportMultipleHttpRequestMessagePropertiesForKey(string key, IEnumerable<PropertyModel> _)

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
@@ -358,6 +358,18 @@ namespace RestEase.Implementation.Emission
             this.AddDiagnostic(methodMustHaveValidReturnType, method.MethodSymbol.Locations);
         }
 
+        private static readonly DiagnosticDescriptor queryAttributeConflictWithRawQueryString = CreateDescriptor(
+            DiagnosticCode.QueryConflictWithRawQueryString,
+            "Parameter attribute RawQueryString must not be specified along with Query",
+            "Method '{0}': parameter '{1}', [RawQueryString] must not be specified along with [Query]");
+        public void ReportQueryAttributeConflictWithRawQueryString(MethodModel method, ParameterModel parameter)
+        {
+            this.AddDiagnostic(
+                queryAttributeConflictWithRawQueryString,
+                SymbolLocations(parameter.ParameterSymbol),
+                method.MethodSymbol.Name, parameter.Name);
+        }
+
         // -----------------------------------------------------------
         // Not shared with the Emit DiagnosticReporter
 

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
@@ -274,19 +274,6 @@ namespace RestEase.Implementation.Emission
                 key);
         }
 
-        private static readonly DiagnosticDescriptor parameterMustHaveZeroOrOneAttributes = CreateDescriptor(
-            DiagnosticCode.ParameterMustHaveZeroOrOneAttributes,
-            "Method parameters must not have zero or one attributes",
-            "Method parameter '{0}' has {1} attributes, but it must have zero or one");
-        public void ReportParameterMustHaveZeroOrOneAttributes(MethodModel _, ParameterModel parameter, List<AttributeModel> attributes)
-        {
-            this.AddDiagnostic(
-                parameterMustHaveZeroOrOneAttributes,
-                SymbolLocations(parameter.ParameterSymbol),
-                parameter.Name,
-                attributes.Count);
-        }
-
         private static readonly DiagnosticDescriptor parameterMustNotBeByRef = CreateDescriptor(
             DiagnosticCode.ParameterMustNotBeByRef,
             "Method parameters must not not be ref, in or out",

--- a/src/Common/Implementation/ImplementationGenerator.cs
+++ b/src/Common/Implementation/ImplementationGenerator.cs
@@ -273,10 +273,7 @@ namespace RestEase.Implementation
                 }
                 else
                 {
-                    if (attributes.Count > 1)
-                    {
-                        this.diagnostics.ReportParameterMustHaveZeroOrOneAttributes(method, parameter, attributes);
-                    }
+                    this.ValidateParameterAttributeCombinations(method, parameter);
 
                     if (parameter.HeaderAttribute != null)
                     {
@@ -291,40 +288,47 @@ namespace RestEase.Implementation
 
                         methodEmitter.EmitAddHeaderParameter(parameter);
                     }
-                    else if (parameter.PathAttribute != null)
+
+                    if (parameter.PathAttribute != null)
                     {
                         methodEmitter.EmitAddPathParameter(
                             parameter,
                             serializationMethods.ResolvePath(parameter.PathAttribute.Attribute.SerializationMethod));
                     }
-                    else if (parameter.QueryAttribute != null)
+
+                    if (parameter.QueryAttribute != null)
                     {
                         methodEmitter.EmitAddQueryParameter(
                             parameter,
                             serializationMethods.ResolveQuery(parameter.QueryAttribute.Attribute.SerializationMethod));
                     }
-                    else if (parameter.HttpRequestMessagePropertyAttribute != null)
+
+                    if (parameter.HttpRequestMessagePropertyAttribute != null)
                     {
                         methodEmitter.EmitAddHttpRequestMessagePropertyParameter(parameter);
                     }
-                    else if (parameter.RawQueryStringAttribute != null)
+
+                    if (parameter.RawQueryStringAttribute != null)
                     {
                         methodEmitter.EmitAddRawQueryStringParameter(parameter);
                     }
-                    else if (parameter.QueryMapAttribute != null)
+
+                    if (parameter.QueryMapAttribute != null)
                     {
                         if (!methodEmitter.TryEmitAddQueryMapParameter(parameter, serializationMethods.ResolveQuery(parameter.QueryMapAttribute.Attribute.SerializationMethod)))
                         {
                             this.diagnostics.ReportQueryMapParameterIsNotADictionary(method, parameter);
                         }
                     }
-                    else if (parameter.BodyAttribute != null)
+
+                    if (parameter.BodyAttribute != null)
                     {
                         methodEmitter.EmitSetBodyParameter(
                             parameter,
                             serializationMethods.ResolveBody(parameter.BodyAttribute.Attribute.SerializationMethod));
                     }
-                    else
+
+                    if (attributes.Count == 0)
                     {
                         methodEmitter.EmitAddQueryParameter(parameter, serializationMethods.ResolveQuery(QuerySerializationMethod.Default));
                     }
@@ -488,6 +492,14 @@ namespace RestEase.Implementation
             foreach (var @params in duplicateParams)
             {
                 this.diagnostics.ReportMultipleHttpRequestMessageParametersForKey(method, @params.Key, @params);
+            }
+        }
+
+        private void ValidateParameterAttributeCombinations(MethodModel method, ParameterModel parameter)
+        {
+            if (parameter.QueryAttribute != null && parameter.RawQueryStringAttribute != null)
+            {
+                this.diagnostics.ReportQueryAttributeConflictWithRawQueryString(method, parameter);
             }
         }
     }

--- a/src/RestEase.UnitTests/ImplementationFactoryTests/MultipleParameterAttributesTests.cs
+++ b/src/RestEase.UnitTests/ImplementationFactoryTests/MultipleParameterAttributesTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace RestEase.UnitTests.ImplementationFactoryTests
+{
+    public class MultipleParameterAttributesTests : ImplementationFactoryTestsBase
+    {
+        public interface IHasMultipleParameterAttributes
+        {
+            [Get("/{bar}")]
+            Task FooAsync([Query, Header("header1"), Body, Path, HttpRequestMessageProperty("prop1")] string bar);
+        }
+
+        public MultipleParameterAttributesTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void HandlesMultipleParameterAttributes()
+        {
+            var requestInfo = this.Request<IHasMultipleParameterAttributes>(x => x.FooAsync("boom"));
+
+            Assert.Single(requestInfo.QueryParams);
+            Assert.Single(requestInfo.HeaderParams);
+            Assert.NotNull(requestInfo.BodyParameterInfo);
+            Assert.Single(requestInfo.PathParams);
+            Assert.Single(requestInfo.HttpRequestMessageProperties);
+        }
+    }
+}

--- a/src/RestEase.UnitTests/ImplementationFactoryTests/SanityCheckTests.cs
+++ b/src/RestEase.UnitTests/ImplementationFactoryTests/SanityCheckTests.cs
@@ -40,12 +40,6 @@ namespace RestEase.UnitTests.ImplementationFactoryTests
             string ReturnsString();
         }
 
-        public interface IHasMethodParameterWithConflictAttributes
-        {
-            [Get]
-            Task FooAsync([Query, RawQueryString] string foo);
-        }
-
         public interface IHasEvents
         {
             event EventHandler Foo;
@@ -138,17 +132,6 @@ namespace RestEase.UnitTests.ImplementationFactoryTests
                 // (7,20): Error REST019: Method must have a return type of Task or Task<T>
                 // ReturnsString
                 Diagnostic(DiagnosticCode.MethodMustHaveValidReturnType, "ReturnsString").WithLocation(7, 20)
-            );
-        }
-
-        [Fact]
-        public void ThrowsIfQueryAttributeWithRawQueryStringWAttribute()
-        {
-            VerifyDiagnostics<IHasMethodParameterWithConflictAttributes>(
-                // (4,27): Error REST040: Method 'FooAsync': [Query] parameter must not specified along with [RawQueryString]
-                // [Query, RawQueryString] string foo
-                Diagnostic(DiagnosticCode.QueryConflictWithRawQueryString, @"[Query, RawQueryString] string foo")
-                    .WithLocation(4, 27)
             );
         }
 

--- a/src/RestEase.UnitTests/ImplementationFactoryTests/SanityCheckTests.cs
+++ b/src/RestEase.UnitTests/ImplementationFactoryTests/SanityCheckTests.cs
@@ -40,10 +40,10 @@ namespace RestEase.UnitTests.ImplementationFactoryTests
             string ReturnsString();
         }
 
-        public interface IHasMethodParameterWithMultipleAttributes
+        public interface IHasMethodParameterWithConflictAttributes
         {
             [Get]
-            Task FooAsync([Query, HttpRequestMessageProperty] string foo);
+            Task FooAsync([Query, RawQueryString] string foo);
         }
 
         public interface IHasEvents
@@ -142,12 +142,12 @@ namespace RestEase.UnitTests.ImplementationFactoryTests
         }
 
         [Fact]
-        public void ThrowsIfMethodWithoutAttributes()
+        public void ThrowsIfQueryAttributeWithRawQueryStringWAttribute()
         {
-            VerifyDiagnostics<IHasMethodParameterWithMultipleAttributes>(
-                // (4,27): Error REST025: Method parameter 'foo' has 2 attributes, but it must have zero or one
-                // [Query, HttpRequestMessageProperty] string foo
-                Diagnostic(DiagnosticCode.ParameterMustHaveZeroOrOneAttributes, @"[Query, HttpRequestMessageProperty] string foo")
+            VerifyDiagnostics<IHasMethodParameterWithConflictAttributes>(
+                // (4,27): Error REST040: Method 'FooAsync': [Query] parameter must not specified along with [RawQueryString]
+                // [Query, RawQueryString] string foo
+                Diagnostic(DiagnosticCode.QueryConflictWithRawQueryString, @"[Query, RawQueryString] string foo")
                     .WithLocation(4, 27)
             );
         }


### PR DESCRIPTION
Close #171

Change proposed:
1. Remove the parameter attribute count check. Previously at most one attribute is allowed.
2. Add validation to report invalid attribute combinations on the same parameter. Currently, just report for `Query` with `RawQueryString`, please suggest if any.
3. Update and add tests