### PR TITLE
close #152 accepts IEnumerable<KeyValuePair<,>> for QueryMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ public interface ISomeApi
 
 Sometimes you have a load of query parameters, or they're generated dynamically, etc. In this case, you may want to supply a dictionary of query parameters, rather than specifying a load of method parameters.
 
-To facilitate this, you may decorate one or more method parameters with `[QueryMap]`. The parameter type must be an `IDictionary<TKey, TValue>`.
+To facilitate this, you may decorate one or more method parameters with `[QueryMap]`. The parameter type must be an `IEnumerable<KeyValuePair<TKey, TValue>>`(`IDictionary<,>` already inherited).
 
 Query maps are handled the same way as other query parameters: serialization, handling of enumerables, null values, etc, behave the same. You can control whether values are serialized using a custom serializer or `ToString()` using e.g. `[QueryMap(QuerySerializationMethod.Serialized)]`.
 
@@ -367,9 +367,9 @@ For example:
 public interface ISomeApi
 {
     [Get("search")]
-    // I've used IDictionary<string, string[]> here, but you can use whatever type parameters you like,
-    // or any type which implements IDictionary<TKey, TValue>
-    Task<SearchResult> SearchBlogPostsAsync([QueryMap] IDictionary<string, string[]> filters);
+    // I've used Dictionary<string, string[]> here, but you can use whatever type parameters you like,
+    // or any type which implements IEnumerable<KeyValuePair<TKey, TValue>>
+    Task<SearchResult> SearchBlogPostsAsync([QueryMap] Dictionary<string, string[]> filters);
 }
 
 var api = RestClient.For<ISomeApi>("https://api.example.com");

--- a/src/Common/Implementation/DiagnosticCode.cs
+++ b/src/Common/Implementation/DiagnosticCode.cs
@@ -21,7 +21,7 @@ namespace RestEase.Implementation
         HeaderMustNotHaveColonInName = 10,
         PropertyMustBeReadWrite = 11,
         HeaderPropertyWithValueMustBeNullable = 12,
-        QueryMapParameterIsNotADictionary = 13,
+        QueryMapParameterIsNotKeyValuePairs = 13,
         AllowAnyStatusCodeAttributeNotAllowedOnParentInterface = 14,
         EventsNotAllowed = 15,
         PropertyMustBeReadOnly = 16,

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Emit.cs
@@ -235,8 +235,8 @@ namespace RestEase.Implementation.Emission
         public void ReportQueryMapParameterIsNotADictionary(MethodModel method, ParameterModel _)
         {
             throw new ImplementationCreationException(
-                DiagnosticCode.QueryMapParameterIsNotADictionary,
-                $"Method '{method.MethodInfo.Name}': [QueryMap] parameter is not of type IDictionary or IDictionary<TKey, TValue> (or one of their descendents)");
+                DiagnosticCode.QueryMapParameterIsNotKeyValuePairs,
+                $"Method '{method.MethodInfo.Name}': [QueryMap] parameter is not of type IEnumerable<KeyValuePair<TKey, TValue>> (or one of its descendents)");
         }
 
         public void ReportHeaderParameterMustNotHaveValue(MethodModel method, ParameterModel parameter)

--- a/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
+++ b/src/Common/Implementation/Emission/DiagnosticReporter.Roslyn.cs
@@ -315,9 +315,9 @@ namespace RestEase.Implementation.Emission
         }
 
         private static readonly DiagnosticDescriptor queryMapParameterIsNotADictionary = CreateDescriptor(
-            DiagnosticCode.QueryMapParameterIsNotADictionary,
+            DiagnosticCode.QueryMapParameterIsNotKeyValuePairs,
             "QueryMap parameters must be dictionaries",
-            "[QueryMap] parameter is not of the type IDictionary or IDictionary<TKey, TValue> (or their descendents)");
+            "[QueryMap] parameter is not of the type IEnumerable<KeyValuePair<TKey, TValue>> (or its descendents)");
         public void ReportQueryMapParameterIsNotADictionary(MethodModel _, ParameterModel parameter)
         {
             this.AddDiagnostic(queryMapParameterIsNotADictionary, SymbolLocations(parameter.ParameterSymbol));

--- a/src/Common/Implementation/Emission/MethodEmitter.Emit.cs
+++ b/src/Common/Implementation/Emission/MethodEmitter.Emit.cs
@@ -401,7 +401,7 @@ namespace RestEase.Implementation.Emission
 
         private static MethodInfo? MakeQueryMapMethodInfo(Type queryMapType)
         {
-            var nullableDictionaryTypes = DictionaryTypesOfType(queryMapType);
+            var nullableDictionaryTypes = EnumerableKeyValueTypesOfType(queryMapType);
             if (nullableDictionaryTypes == null)
                 return null;
 
@@ -424,14 +424,18 @@ namespace RestEase.Implementation.Emission
             }
         }
 
-        private static KeyValuePair<Type, Type>? DictionaryTypesOfType(Type input)
+        private static KeyValuePair<Type, Type>? EnumerableKeyValueTypesOfType(Type input)
         {
             foreach (var baseType in EnumerableExtensions.Concat(input, input.GetTypeInfo().GetInterfaces()))
             {
-                if (baseType.GetTypeInfo().IsGenericType && baseType.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                if (baseType.GetTypeInfo().IsGenericType && baseType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                 {
-                    var genericArguments = baseType.GetTypeInfo().GetGenericArguments();
-                    return new KeyValuePair<Type, Type>(genericArguments[0], genericArguments[1]);
+                    var enumeratedType = baseType.GetTypeInfo().GetGenericArguments()[0].GetTypeInfo();
+                    if (enumeratedType.IsGenericType && enumeratedType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+                    {
+                        var genericArguments = enumeratedType.GetGenericArguments();
+                        return new KeyValuePair<Type, Type>(genericArguments[0], genericArguments[1]);
+                    }
                 }
             }
 

--- a/src/Common/Implementation/Emission/MethodEmitter.Roslyn.cs
+++ b/src/Common/Implementation/Emission/MethodEmitter.Roslyn.cs
@@ -339,7 +339,7 @@ namespace RestEase.Implementation.Emission
 
         private string? GetQueryMapMethodName(ITypeSymbol queryMapType)
         {
-            var nullableDictionaryTypes = this.DictionaryTypesOfType(queryMapType);
+            var nullableDictionaryTypes = this.EnumerableKeyValueTypesOfType(queryMapType);
             if (nullableDictionaryTypes == null)
                 return null;
 
@@ -360,18 +360,21 @@ namespace RestEase.Implementation.Emission
             }
         }
 
-        private KeyValuePair<ITypeSymbol, ITypeSymbol>? DictionaryTypesOfType(ITypeSymbol input)
+        private KeyValuePair<ITypeSymbol, ITypeSymbol>? EnumerableKeyValueTypesOfType(ITypeSymbol input)
         {
             KeyValuePair<ITypeSymbol, ITypeSymbol>? result = null;
             if (input is INamedTypeSymbol value)
             {
                 foreach (var baseType in value.AllInterfaces.Prepend(value))
                 {
-                    if (baseType.IsGenericType && SymbolEqualityComparer.Default.Equals(baseType.ConstructedFrom, this.wellKnownSymbols.IDictionaryKV))
+                    if (baseType.IsGenericType && SymbolEqualityComparer.Default.Equals(baseType.ConstructedFrom, this.wellKnownSymbols.IEnumerableT))
                     {
-                        result = new KeyValuePair<ITypeSymbol, ITypeSymbol>(
-                            baseType.TypeArguments[0], baseType.TypeArguments[1]);
-                        break;
+                        var enumeratedType = baseType.TypeArguments[0];
+                        result = this.KeyValueTypesOfType(enumeratedType);
+                        if (result != null)
+                        {
+                            break;
+                        }
                     }
                 }
             }
@@ -380,7 +383,33 @@ namespace RestEase.Implementation.Emission
                 // Are any of its constraints suitable dictionaries
                 foreach (var constraint in typeParameter.ConstraintTypes)
                 {
-                    result = this.DictionaryTypesOfType(constraint);
+                    result = this.EnumerableKeyValueTypesOfType(constraint);
+                    if (result != null)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private KeyValuePair<ITypeSymbol, ITypeSymbol>? KeyValueTypesOfType(ITypeSymbol input)
+        {
+            KeyValuePair<ITypeSymbol, ITypeSymbol>? result = null;
+            if (input is INamedTypeSymbol namedType)
+            {
+                if (namedType.IsGenericType && SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, this.wellKnownSymbols.KeyValuePairKV))
+                {
+                    result = new KeyValuePair<ITypeSymbol, ITypeSymbol>(namedType.TypeArguments[0], namedType.TypeArguments[1]);
+                }
+            }
+            else if (input is ITypeParameterSymbol typeParameter)
+            {
+                // Are any of its constraints suitable KeyValuePair
+                foreach (var constraint in typeParameter.ConstraintTypes)
+                {
+                    result = this.KeyValueTypesOfType(constraint);
                     if (result != null)
                     {
                         break;

--- a/src/RestEase.SourceGenerator/Implementation/WellKnownSymbols.cs
+++ b/src/RestEase.SourceGenerator/Implementation/WellKnownSymbols.cs
@@ -101,8 +101,8 @@ namespace RestEase.SourceGenerator.Implementation
         private INamedTypeSymbol? ienumerableT;
         public INamedTypeSymbol? IEnumerableT => this.ienumerableT ??= this.LookupKnownSystem("System.Collections.Generic.IEnumerable`1");
 
-        private INamedTypeSymbol? idictionaryKV;
-        public INamedTypeSymbol? IDictionaryKV => this.idictionaryKV ??= this.LookupKnownSystem("System.Collections.Generic.IDictionary`2");
+        private INamedTypeSymbol? keyValuePairKV;
+        public INamedTypeSymbol? KeyValuePairKV => this.keyValuePairKV ??= this.LookupKnownSystem("System.Collections.Generic.KeyValuePair`2");
 
         private INamedTypeSymbol? httpMethod;
         public INamedTypeSymbol? HttpMethod => this.httpMethod ??= this.LookupKnownSystem("System.Net.Http.HttpMethod");

--- a/src/RestEase/Implementation/RequestInfo.cs
+++ b/src/RestEase/Implementation/RequestInfo.cs
@@ -186,7 +186,7 @@ namespace RestEase.Implementation
         /// <typeparam name="TValue">Type of value in the query map</typeparam>
         /// <param name="serializationMethod">Method to use to serialize the value</param>
         /// <param name="queryMap">Query map to add</param>
-        public void AddQueryMap<TKey, TValue>(QuerySerializationMethod serializationMethod, IDictionary<TKey, TValue> queryMap)
+        public void AddQueryMap<TKey, TValue>(QuerySerializationMethod serializationMethod, IEnumerable<KeyValuePair<TKey, TValue>> queryMap)
         {
             if (queryMap == null)
                 return;
@@ -223,7 +223,8 @@ namespace RestEase.Implementation
         /// <typeparam name="TElement">Type of element in the value</typeparam>
         /// <param name="serializationMethod">Method to use to serialize the value</param>
         /// <param name="queryMap">Query map to add</param>
-        public void AddQueryCollectionMap<TKey, TValue, TElement>(QuerySerializationMethod serializationMethod, IDictionary<TKey, TValue> queryMap) where TValue : IEnumerable<TElement>
+        public void AddQueryCollectionMap<TKey, TValue, TElement>(QuerySerializationMethod serializationMethod, IEnumerable<KeyValuePair<TKey, TValue>> queryMap)
+            where TValue : IEnumerable<TElement>
         {
             if (queryMap == null)
                 return;


### PR DESCRIPTION
Change Proposed:
1. Change parameter from `IDictionary<TKey, TValue>` to `IEnumerable<KeyValuePair<TKey, TValue>>` for `RequestInfo.AddQueryMap(...)` and `RequestInfo.AddQueryCollectionMap(...)`
2. Update method emitters to reflect such change.
3. Reword diagnostic code and message
4. Add tests
5. Update README