### PR TITLE
Fix #252.

### DIFF
--- a/src/RestEase.SourceGenerator/Implementation/Processor.cs
+++ b/src/RestEase.SourceGenerator/Implementation/Processor.cs
@@ -8,6 +8,7 @@ namespace RestEase.SourceGenerator.Implementation
     {
         private readonly GeneratorExecutionContext context;
         private readonly RoslynImplementationFactory factory;
+        private readonly Dictionary<string, int> nameToIndex = new Dictionary<string, int>();
 
         public Processor(GeneratorExecutionContext context)
         {
@@ -72,7 +73,13 @@ namespace RestEase.SourceGenerator.Implementation
 
             if (sourceText != null)
             {
-                this.context.AddSource("RestEase_" + namedTypeSymbol.Name + ".g", sourceText);
+                var name = namedTypeSymbol.Name;
+                if (!this.nameToIndex.TryGetValue(name, out var index))
+                {
+                    index = 1;
+                }
+                this.context.AddSource("RestEase_" + name + "_" + index + ".g", sourceText);
+                this.nameToIndex[name] = ++index;
             }
         }
     }


### PR DESCRIPTION
Allow multiple interfaces with the same name by adding an index to the generated source file name. Chose to use an index over adding the namespace to prevent long file names due to long namespace names.

**Checklist**

Thanks for contributing! Before we start, there are a few things we need to check:

1. This Pull Request has a corresponding Issue.
2. You've discussed your intention to work on this feature/bug fix.
3. This feature branch is based on develop (**not** master). The bar above should say "base: develop".

Thanks!