### PR TITLE
Fix/multiple interfaces with same name in source generator

### DIFF
--- a/src/RestEase.SourceGenerator/Implementation/Processor.cs
+++ b/src/RestEase.SourceGenerator/Implementation/Processor.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -8,6 +10,8 @@ namespace RestEase.SourceGenerator.Implementation
     {
         private readonly GeneratorExecutionContext context;
         private readonly RoslynImplementationFactory factory;
+        private static readonly SymbolDisplayFormat generatedFileName = new SymbolDisplayFormat(
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
         public Processor(GeneratorExecutionContext context)
         {
@@ -72,7 +76,8 @@ namespace RestEase.SourceGenerator.Implementation
 
             if (sourceText != null)
             {
-                this.context.AddSource("RestEase_" + namedTypeSymbol.Name + ".g", sourceText);
+                var hintName = "RestEase_" + namedTypeSymbol.ToDisplayString(generatedFileName) + ".g";
+                this.context.AddSource(hintName, sourceText);
             }
         }
     }

--- a/src/RestEase.SourceGenerator/Implementation/Processor.cs
+++ b/src/RestEase.SourceGenerator/Implementation/Processor.cs
@@ -76,8 +76,13 @@ namespace RestEase.SourceGenerator.Implementation
 
             if (sourceText != null)
             {
-                var hintName = "RestEase_" + namedTypeSymbol.ToDisplayString(generatedFileName) + ".g";
-                this.context.AddSource(hintName, sourceText);
+                var hintNameBase = "RestEase_" + namedTypeSymbol.ToDisplayString(generatedFileName);
+                if (namedTypeSymbol.IsGenericType)
+                {
+                    var genericParameterCount = namedTypeSymbol.TypeParameters.Length;
+                    hintNameBase += "{" + genericParameterCount + "}";
+                } 
+                this.context.AddSource(hintNameBase + ".g", sourceText);
             }
         }
     }


### PR DESCRIPTION
Fixes #252.

Add support to the source generator for multiple interfaces with the same name but in different assemblies, or with different number of generics type parameters.